### PR TITLE
Fix for allowing compile error message of less compiler to be a ConsString also.

### DIFF
--- a/sbt-less/src/main/scala/com/untyped/sbtless/LessSource.scala
+++ b/sbt-less/src/main/scala/com/untyped/sbtless/LessSource.scala
@@ -144,7 +144,10 @@ case class LessSource(graph: Graph, src: File) extends Source {
             val error   = e.getValue.asInstanceOf[Scriptable]
             val line    = ScriptableObject.getProperty(error, "line"   ).asInstanceOf[Double].intValue
             val column  = ScriptableObject.getProperty(error, "column" ).asInstanceOf[Double].intValue
-            val message = ScriptableObject.getProperty(error, "message").asInstanceOf[String]
+            val message = ScriptableObject.getProperty(error, "message") match {
+              case msg:String => msg
+              case msg:ConsString => msg.toString
+            }
             sys.error("%s error: %s [%s,%s]: %s".format(graph.pluginName, src.getName, line, column, message))
         }
       }


### PR DESCRIPTION
I had the case in which the less task was issuing the following error when compiling and a variable wasn't defined properly in less:
[error](frontend/compile:less) java.lang.ClassCastException: org.mozilla.javascript.ConsString cannot be cast to java.lang.String

After this fix the error message is displayed correctly:
[error](frontend/compile:less) sbt-less error: components.less [44,20]: variable @lightGreyBG is undefined

Some errors still returned String as error message so the match seems necessary to accomodate both.

I would be glad if this would make it into the 0.8 release as I was getting this error quite frequently.

Kind regards,
Roland
