### PR TITLE
Fix variableRenamingPolicy setting not working

### DIFF
--- a/sbt-js/src/main/scala/com/untyped/sbtjs/Plugin.scala
+++ b/sbt-js/src/main/scala/com/untyped/sbtjs/Plugin.scala
@@ -140,11 +140,11 @@ object Plugin extends sbt.Plugin {
       (out, variableRenamingPolicy, prettyPrint, strictMode, warningLevel, compilationLevel) =>
         val options = new ClosureOptions
 
-        options.variableRenaming = variableRenamingPolicy
-        options.prettyPrint = prettyPrint
-
         compilationLevel.setOptionsForCompilationLevel(options)
         warningLevel.setOptionsForWarningLevel(options)
+
+        options.variableRenaming = variableRenamingPolicy
+        options.prettyPrint = prettyPrint
 
         if(strictMode) {
           options.setLanguageIn(ClosureOptions.LanguageMode.ECMASCRIPT5_STRICT)

--- a/sbt-js/src/sbt-test/sbt-js/base/fixtures/file10.js
+++ b/sbt-js/src/sbt-test/sbt-js/base/fixtures/file10.js
@@ -1,0 +1,1 @@
+function hello(a){alert(a)}hello("Dave");

--- a/sbt-js/src/sbt-test/sbt-js/base/src/main/resources/file10.js
+++ b/sbt-js/src/sbt-test/sbt-js/base/src/main/resources/file10.js
@@ -1,0 +1,5 @@
+function hello(name) {
+  alert(name);
+}
+
+hello("Dave");

--- a/sbt-js/src/sbt-test/sbt-js/base/test
+++ b/sbt-js/src/sbt-test/sbt-js/base/test
@@ -14,6 +14,7 @@ $ exists target/scripted/resources/file6.js
 $ exists target/scripted/resources/file7.notemplate.js
 $ exists target/scripted/resources/file8.js
 $ exists target/scripted/resources/file9.js
+$ exists target/scripted/resources/file10.js
 
 # Check that the JS files have the correct content:
 > contents target/scripted/resources/file1.js            fixtures/file1.js
@@ -25,6 +26,7 @@ $ exists target/scripted/resources/file9.js
 > contents target/scripted/resources/file7.notemplate.js fixtures/file7.notemplate.js
 > contents target/scripted/resources/file8.js            fixtures/file8.js
 > contents target/scripted/resources/file9.js            fixtures/file9.js
+> contents target/scripted/resources/file10.js           fixtures/file10.js
 
 # Check that the JS files were updated by the last compile task:
 $ newer target/scripted/resources/file1.js            fixtures/last-compile-time
@@ -36,6 +38,7 @@ $ newer target/scripted/resources/file6.js            fixtures/last-compile-time
 $ newer target/scripted/resources/file7.notemplate.js fixtures/last-compile-time
 $ newer target/scripted/resources/file8.js            fixtures/last-compile-time
 $ newer target/scripted/resources/file9.js            fixtures/last-compile-time
+$ newer target/scripted/resources/file10.js           fixtures/last-compile-time
 
 # Touch some (but not all) of the source files:
 $ touch src/main/resources/file1.js
@@ -58,6 +61,7 @@ $ sleep 1000
 > contents target/scripted/resources/file7.notemplate.js fixtures/file7.notemplate.js
 > contents target/scripted/resources/file8.js            fixtures/file8.js
 > contents target/scripted/resources/file9.js            fixtures/file9.js
+> contents target/scripted/resources/file10.js           fixtures/file10.js
 
 # Check that only the touched files were updated:
 $ newer target/scripted/resources/file1.js      fixtures/last-compile-time
@@ -69,6 +73,7 @@ $ newer fixtures/last-compile-time                                       target/
 $ newer fixtures/last-compile-time                                       target/scripted/resources/file7.notemplate.js
 $ newer target/scripted/resources/file8.js      fixtures/last-compile-time
 $ newer target/scripted/resources/file9.js      fixtures/last-compile-time
+$ newer target/scripted/resources/file10.js     fixtures/last-compile-time
 
 # Clean everything:
 > clean

--- a/sbt-js/src/sbt-test/sbt-js/variable-renaming/build.sbt
+++ b/sbt-js/src/sbt-test/sbt-js/variable-renaming/build.sbt
@@ -1,0 +1,32 @@
+name := "variable-renaming"
+
+logLevel := Level.Debug
+
+seq(jsSettings : _*)
+
+(resourceManaged in (Compile, JsKeys.js)) <<= (target in Compile) { _ / "scripted" }
+
+JsKeys.variableRenamingPolicy in Compile := VariableRenamingPolicy.OFF
+
+JsKeys.templateProperties in Compile := {
+  val props = new java.util.Properties
+  props.setProperty("test.user.name", "Mustache")
+  props
+}
+
+InputKey[Unit]("contents") <<= inputTask { (argsTask: TaskKey[Seq[String]]) =>
+  (argsTask, streams) map { (args, out) =>
+    args match {
+      case Seq(actual, expected) =>
+        if(IO.read(file(actual)).trim.equals(IO.read(file(expected)).trim)) {
+          out.log.debug("Contents match")
+        } else {
+          error("\nContents of %s\n%s\ndoes not match %s\n%s\n".format(
+                actual,
+                IO.read(file(actual)),
+                expected,
+                IO.read(file(expected))))
+        }
+    }
+  }
+}

--- a/sbt-js/src/sbt-test/sbt-js/variable-renaming/fixtures/file1.js
+++ b/sbt-js/src/sbt-test/sbt-js/variable-renaming/fixtures/file1.js
@@ -1,0 +1,1 @@
+function hello(name){alert(name)}hello("Dave");

--- a/sbt-js/src/sbt-test/sbt-js/variable-renaming/project/plugins.sbt
+++ b/sbt-js/src/sbt-test/sbt-js/variable-renaming/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.untyped" % "sbt-js" % "0.8-M1")

--- a/sbt-js/src/sbt-test/sbt-js/variable-renaming/src/main/resources/file1.js
+++ b/sbt-js/src/sbt-test/sbt-js/variable-renaming/src/main/resources/file1.js
@@ -1,0 +1,5 @@
+function hello(name) {
+  alert(name);
+}
+
+hello("Dave");

--- a/sbt-js/src/sbt-test/sbt-js/variable-renaming/test
+++ b/sbt-js/src/sbt-test/sbt-js/variable-renaming/test
@@ -1,0 +1,8 @@
+# Compile all sources:
+> js
+
+# Check that the JS files exist:
+$ exists target/scripted/resources/file1.js
+
+# Check that the JS files have the correct content:
+> contents target/scripted/resources/file1.js            fixtures/file1.js


### PR DESCRIPTION
Tests have been added to base to see that the default setting actually renames variables. `variable-renaming` test sees if setting it to off actually works.
