### PR TITLE
Update README.md

### DIFF
--- a/sbt-less/README.md
+++ b/sbt-less/README.md
@@ -89,7 +89,8 @@ valid Less versions include:
 
  - `LessVersion.Less113`
  - `LessVersion.Less115`
- - `LessVersion.Less130` (the default)
+ - `LessVersion.Less130`
+ - `LessVersion.Less142` (the default)
 
 ## Usage
 


### PR DESCRIPTION
looks like 1.4.2 is current default version of less.
