### PR TITLE
Partially implement javascript sourcemap support

### DIFF
--- a/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
+++ b/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
@@ -50,8 +50,14 @@ trait Source extends com.untyped.sbtgraph.Source {
         warnings.foreach(err => graph.log.warn(err.toString))
       }
 
+      val mapDes = new File(des.getPath+".map")
+
       IO.createDirectory(new File(des.getParent))
-      IO.write(des, compiler.toSource)
+      IO.write(des, compiler.toSource+"\n"+"//@ sourceMappingURL="+mapDes.getName)
+
+      val mapWriter = new java.io.FileWriter(mapDes)
+      compiler.getSourceMap.appendTo(mapWriter, des.getName)
+      mapWriter.close()
 
       Some(des)
     }

--- a/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
+++ b/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
@@ -37,6 +37,7 @@ trait Source extends com.untyped.sbtgraph.Source {
       new SourceMap.LocationMapping(source.src.getParent, ".")
     }
     graph.closureOptions.setSourceMapLocationMappings(locationMappings)
+    graph.closureOptions.setSourceMapOutputPath(graph.targetDir.getAbsolutePath)
 
     val result =
       compiler.compile(

--- a/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
+++ b/sbt-js/src/main/scala/com/untyped/sbtjs/Source.scala
@@ -2,7 +2,8 @@ package com.untyped.sbtjs
 
 import com.google.javascript.jscomp.{
   SourceFile => ClosureSource,
-  Compiler => ClosureCompiler
+  Compiler => ClosureCompiler,
+  SourceMap
 }
 import sbt._
 import scala.collection.JavaConversions._
@@ -29,6 +30,13 @@ trait Source extends com.untyped.sbtgraph.Source {
 
     graph.log.debug("  sources:")
     mySources.foreach(x => graph.log.debug("    " + x))
+
+    val allAncestors = graph.sources.flatMap(graph.ancestors).diff(graph.sources)
+    val rootSources = graph.sources.diff(allAncestors)
+    val locationMappings = rootSources.map { source =>
+      new SourceMap.LocationMapping(source.src.getParent, ".")
+    }
+    graph.closureOptions.setSourceMapLocationMappings(locationMappings)
 
     val result =
       compiler.compile(


### PR DESCRIPTION
This is more of a question than an actual pull request. Closure compiler supports generating sourcemaps so that the compiled JS can be easily debugged. This is easy enough to implement, but the problem is the sbt-graph API only supports one file generated per Source. So the files reported to sbt (per resource generator contract) are lacking. I'm not sure how to proceed from here.
